### PR TITLE
Update Gson to fix CVE-2022-25647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <spark.version>2.7.2</spark.version>
     <spark.freemarker.version>2.7.1</spark.freemarker.version>
     <freemarker.version>2.3.28</freemarker.version>
-    <gson.version>2.8.5</gson.version>
+    <gson.version>2.9.0</gson.version>
     <slf4j.version>1.7.25</slf4j.version>
     
     <!-- Test build dependency versions -->


### PR DESCRIPTION
### Description

This PR simply updates Gson from `2.8.5` to `2.9.0` which includes a patch for CVE-2022-25647.